### PR TITLE
Add tracepoints-and-monitoring-the-bitcoin-network review to chaincode-labs/chaincode-podcast

### DIFF
--- a/chaincode-labs/chaincode-podcast/tracepoints-and-monitoring-the-bitcoin-network.md
+++ b/chaincode-labs/chaincode-podcast/tracepoints-and-monitoring-the-bitcoin-network.md
@@ -1,14 +1,13 @@
 ---
 title: "Tracepoints and monitoring the Bitcoin network"
-transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+transcript_by: BalogunofAfrica via review.btctranscripts.com
 media: https://podcasters.spotify.com/pod/show/chaincode/episodes/0xB10C--Tracepoints-and-monitoring-the-Bitcoin-network-e1jipel
-tags: []
-speakers: ['0xB10C']
-categories: ['podcast']
 date: 2022-06-06
+speakers: ["0xB10C"]
+categories: ["podcast"]
 ---
 Speaker 0: 00:00:00
-
+Test
 Hey, Merch.
 What up?
 We are back in the studio.


### PR DESCRIPTION
This PR adds [tracepoints-and-monitoring-the-bitcoin-network](https://podcasters.spotify.com/pod/show/chaincode/episodes/0xB10C--Tracepoints-and-monitoring-the-Bitcoin-network-e1jipel) transcript review to the chaincode-labs/chaincode-podcast directory.